### PR TITLE
docs: generalize local paths

### DIFF
--- a/FRONTEND_INTEGRATION.md
+++ b/FRONTEND_INTEGRATION.md
@@ -79,7 +79,7 @@ localStorage.setItem('accessToken', response.token);
 
 1. Start the backend server:
    ```
-   cd /Users/rekcal/rare-perfume-cms
+   cd path/to/rare-perfume-cms
    cd backend
    npm install
    npm start
@@ -87,14 +87,14 @@ localStorage.setItem('accessToken', response.token);
 
 2. Start the CMS development server:
    ```
-   cd /Users/rekcal/rare-perfume-cms
+   cd path/to/rare-perfume-cms
    npm install
    npm run dev
    ```
 
 3. Start the frontend development server:
    ```
-   cd /Users/rekcal/rare-parfume-website
+   cd path/to/rare-parfume-website
    npm install
    npm start
    ```

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The application uses a custom color palette defined in \`tailwind.config.js\`:
 
 ## Frontend Integration
 
-This CMS backend is designed to work with the Rare Perfume frontend website located at `/Users/rekcal/rare-parfume-website`.
+This CMS backend is designed to work with the Rare Perfume frontend website located at `path/to/rare-parfume-website`.
 
 ### Connection Setup
 


### PR DESCRIPTION
## Summary
- replace hard-coded absolute paths with generic placeholders in docs

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_688876bb01588326af98164d640a4c02