### PR TITLE
Use placeholder secret in backend env

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ rare-perfume-cms/
    \`\`\`bash
    cp .env.example .env
    \`\`\`
-   Edit the \`.env\` file with your API endpoint and other configuration.
+Edit the \`.env\` file with your API endpoint and other configuration.
+For production deployments, replace placeholder secrets (e.g., \`JWT_SECRET\` in
+\`backend/.env\`) with strong, unique values.
 
 5. **Start the development server**
    \`\`\`bash

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -38,8 +38,9 @@ ACCOUNT_HOLDER=NGUYEN VAN A
 CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 
 # Security
-JWT_SECRET=rare_perfume_secret_key_2024
+JWT_SECRET=changeme
 ```
+👉 **Lưu ý**: Hãy thay đổi `JWT_SECRET` thành giá trị bảo mật khi triển khai sản phẩm thực tế.
 
 ### Bước 2: Cài đặt Dependencies
 

--- a/backend/.env
+++ b/backend/.env
@@ -1,5 +1,5 @@
 PORT=3001
 NODE_ENV=development
-JWT_SECRET=rare_perfume_secret_key_change_in_production
+JWT_SECRET=changeme
 JWT_EXPIRY=7d
 CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:3001


### PR DESCRIPTION
## Summary
- scrub default JWT secret from backend/.env
- update setup docs with placeholder and instructions
- note secret replacement in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_688989675f7c8326b81cc6f9d31569ea